### PR TITLE
Ensure the shelf docks properly on relaunch

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>70</string>
+	<string>71</string>
 	<key>NSPrincipalClass</key>
 	<string>QSShelfController</string>
 	<key>QSActions</key>

--- a/QSShelfController.m
+++ b/QSShelfController.m
@@ -36,7 +36,7 @@
 }
 
 + (void)showShelfHidden:(id)sender{
-	[(QSDockingWindow *)[[self sharedInstance]window]orderFrontHidden:sender];
+	[(QSDockingWindow *)[[self sharedInstance] window]orderFrontHidden:sender];
 }
 
 + (id)sharedInstance{
@@ -53,7 +53,11 @@
 // saves the state of the shelf window when Quicksivler goes to quit (used on next QS launch - see +loadPlugIn)
 +(void)saveVisibilityState:(NSNotification *)notif {
     if ([[notif object] isEqualToString:@"QSQuicksilverWillQuitEvent"]) {
-        [[NSUserDefaults standardUserDefaults] setBool:([(QSDockingWindow *)[[self sharedInstance] window] hidden] ? NO : YES) forKey:@"QSGeneralShelfIsVisible"];
+        BOOL visible = ![(QSDockingWindow *)[[self sharedInstance] window] hidden];
+        if (!visible) {
+            visible = [(QSDockingWindow *)[[self sharedInstance] window] canFade];
+        }
+        [[NSUserDefaults standardUserDefaults] setBool:visible forKey:@"QSGeneralShelfIsVisible"];
     }
 }
 


### PR DESCRIPTION
See [here](http://groups.google.com/group/blacktree-quicksilver/browse_thread/thread/1834663216b386ef/9060465d4cc132bc#9060465d4cc132bc) for more information.

Current behaviour: If you have the shelf set to dock, when you relaunch you can't hover over the edge of the screen with the mouse to make it pop back up.

This fix: upon a restart of Quicksilver, the shelf correctly docks on the side of the screen.

The fix: On quit, we need to check if the shelf window is visible (using `hidden`). If not, then we need to check if it `canFade` - i.e. it's docked.

Apparently a docked shelf window is visible according to the OS, but the `hidden` method doesn't say so that it's visible. i.e. when the window is docked, `canFade` returns `yes` but `hidden` returns NO, but even though the window isn't _ACTUALLY_ hidden (it's peeping out from the side of your window)

Confusing :)
