### PR TITLE
load the clipboard history if it's visible OR docked

### DIFF
--- a/QSShelfController.m
+++ b/QSShelfController.m
@@ -23,7 +23,7 @@
 	NSUserDefaults *defaults=[NSUserDefaults standardUserDefaults];
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(saveVisibilityState:) name:@"QSEventNotification" object:nil];
-    if([defaults boolForKey:@"QSGeneralShelfIsVisible"] && ![(QSDockingWindow *)[[self sharedInstance] window] canFade]) {
+    if([defaults boolForKey:@"QSGeneralShelfIsVisible"] || [(QSDockingWindow *)[[self sharedInstance] window] canFade]) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(showShelfHidden:) name:@"QSApplicationDidFinishLaunchingNotification" object:nil];
     }  
 	NSImage *image=[NSImage imageNamed:@"Catalog"];


### PR DESCRIPTION
The window will never be visible _and_ docked, so this check was unnecessary. However, a docked window _does_ need to be loaded into memory on startup in order to respond to mouse events.
