### PR TITLE
don’t instantiate windows prematurely

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -108,5 +108,10 @@
 			<string>QSShelfController</string>
 		</dict>
 	</dict>
+	<key>QSRequirements</key>
+	<dict>
+		<key>version</key>
+		<string>3926</string>
+	</dict>
 </dict>
 </plist>

--- a/QSShelfController.m
+++ b/QSShelfController.m
@@ -35,7 +35,7 @@
 + (void)showShelfHidden:(id)sender
 {
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-	if ([defaults boolForKey:@"QSGeneralShelfIsVisible"] || [(QSDockingWindow *)[[self sharedInstance] window] canFade]) {
+	if ([defaults boolForKey:@"QSGeneralShelfIsVisible"] || [(QSDockingWindow *)[[self sharedInstance] window] isDocked]) {
 		[(QSDockingWindow *)[[self sharedInstance] window]orderFrontHidden:sender];
 	}
 }


### PR DESCRIPTION
My last change was causing docked windows to get instantiated before the handler was available to load icons for the objects in the window. This fixes it.
